### PR TITLE
MainScene BGM작동 문제를 개선하였습니다

### DIFF
--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -489,6 +489,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1086700810}
   - component: {fileID: 1086700809}
+  - component: {fileID: 1086700811}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -562,6 +563,14 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!81 &1086700811
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086700807}
+  m_Enabled: 1
 --- !u!1 &1151920561
 GameObject:
   m_ObjectHideFlags: 0
@@ -742,7 +751,7 @@ MonoBehaviour:
   hurryBGM: {fileID: 8300000, guid: 51ab2b6657e00eb4ab6c5bb269969df6, type: 3}
   clearBGM: {fileID: 8300000, guid: cb429ab029ec71d4cbf35db85243c642, type: 3}
   failBGM: {fileID: 8300000, guid: f3b32dd9a5c455744a274e32c56f58e4, type: 3}
-  hiddenBGM: {fileID: 0}
+  hiddenBGM: {fileID: 8300000, guid: 08d1f61ccfa65de498e610ef00688ca3, type: 3}
   StartBGM: {fileID: 8300000, guid: a45010c3ee3f9094fb82831e397e7c54, type: 3}
   matchMiss: {fileID: 8300000, guid: 802c824776565e54ab9c185a85ff5b06, type: 3}
   Matched: {fileID: 8300000, guid: b20888bdc566ccc418c243dc1d69e010, type: 3}

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -98,6 +98,13 @@ public class AudioManager : MonoBehaviour
         audioSource.Play();
     }
 
+    public void NomalBGM() //clip으로 선정된 MainScene 전용 BGM
+    {
+        audioSource.clip = clip;
+        audioSource.loop = true;
+        audioSource.Play();
+    }
+
     public void OnSceneLoaded(Scene scene, LoadSceneMode mode) // 시작화면(StartScene)에서의 BGM과 (MainScene)에서의 BGM을 바꾸기 로직입니다(실험)
     {
         if (scene.name == "StartScene")

--- a/Assets/Scripts/Gamemanager.cs
+++ b/Assets/Scripts/Gamemanager.cs
@@ -110,7 +110,7 @@ public class GameManager : MonoBehaviour
 
         if (isHiddenStageActive)
         {
-            // AudioManager.instance.HiddenBGM();
+            AudioManager.instance.HiddenBGM();
             hiddenBackground.SetActive(true);
             float limit = currentStage.timeLimit;
 

--- a/Assets/Scripts/RetryButton.cs
+++ b/Assets/Scripts/RetryButton.cs
@@ -22,6 +22,7 @@ public class RetryButton : MonoBehaviour
                 GameManager gameManager= GameManager.instance;
                 UIManager uiManager = UIManager.instance;
                 AudioManager.instance.ClickSFX();
+                AudioManager.instance.NomalBGM();
                 gameManager.selectStageContainer.gameObject.SetActive(true);
                 gameManager.hiddenBackground.SetActive(false);
                 gameManager.endTxt.SetActive(false);

--- a/Assets/Sounds/bgm/HiddenStageBGM.wav.meta
+++ b/Assets/Sounds/bgm/HiddenStageBGM.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 08d1f61ccfa65de498e610ef00688ca3
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 7
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
오디오매니저에 새로운 매서드 NormalBGM을 추가하여 MainScene 전용 BGM으로써 작동하도록 해놨으며,

Retrybutton 누를경우 NormalBGM이 나오도록 해놨습니다.

히든 스테이지 진입시 HiddenStageBGM이 실행되는 코드가 Gamemanager에 적용되었고

동욱님이 노션에 올리신 음원파일을HiddenStageBGM으로 이름을 바꿔서  BGM리소스 폴더에 넣었고,

오디오 매니저에 해당 BGM을 할당해놨습니다.